### PR TITLE
Update npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A clean, responsive documentation template theme for JSDoc 3.
 ## Install
 
 ```bash
-$ npm install --save-dev smeijer:latodoc
+$ npm install --save-dev smeijer/latodoc
 ```
 
 ## Usage


### PR DESCRIPTION
Previously, npm failed to resolve the url:
`npm ERR! Unsupported URL Type: smeijer:latodoc`

This resolves that issue.
