### PR TITLE
Allow to disable the generated date

### DIFF
--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -36,9 +36,11 @@
 
 <br class="clear">
 
+<?js if(env.conf.templates && env.conf.templates.latodoc && env.conf.templates.latodoc.includeDate !== false) { ?>
 <footer>
     Documentation generated at <?js= (new Date()) ?>
 </footer>
+<?js } ?>
 
 <script>prettyPrint();</script>
 <script src="scripts/linenumber.js"></script>


### PR DESCRIPTION
A feature from the default template: https://github.com/jsdoc3/jsdoc/issues/910

The footer would be empty, so I remove it as well.

